### PR TITLE
Fix beacon--movement-> simplification (69843d3)

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -279,10 +279,11 @@ If DELTA is nil, return nil."
        ;; lines. `count-screen-lines' is too slow if the movement had
        ;; thousands of lines.
        (save-excursion
-         (goto-char (min beacon--previous-place (point)))
-         (vertical-motion delta)
-         (> (max (point) beacon--previous-place)
-            (line-beginning-position)))))
+         (let ((p (point)))
+           (goto-char (min beacon--previous-place p))
+           (vertical-motion delta)
+           (> (max p beacon--previous-place)
+              (line-beginning-position))))))
 
 (defun beacon--maybe-push-mark ()
   "Push mark if it seems to be safe."


### PR DESCRIPTION
Commit 69843d3 simplified a bit too much.  The problem is that `vertical-motion` always moves point, and it moves it to `beginning-of-line`.  So the test always failed.  It has to be run with the original value of `point`.

Other than that, that's obviously a much better logic than my original one. ;-)