### PR TITLE
Fix when default backgroud is unspecified-fg or unspecified-bg

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -44,6 +44,13 @@
   :group 'emacs
   :prefix "beacon-")
 
+(defface beacon-fallback
+  '((((class color) (background light))
+     (:background "black"))
+    (((class color) (background dark))
+     (:background "white")))
+  "Fallback background color")
+
 (defvar beacon--timer nil)
 
 (defcustom beacon-push-mark 35
@@ -221,7 +228,10 @@ Only returns `beacon-size' elements."
 
 (defun beacon--color-range ()
   "Return a list of background colors for the beacon."
-  (let* ((bg (color-values (face-attribute 'default :background)))
+  (let* ((default-bg (face-attribute 'default :background))
+         (bg (color-values (if (string-prefix-p "unspecified" default-bg)
+                               (face-attribute 'beacon-fallback :background)
+                             default-bg)))
          (fg (cond
               ((stringp beacon-color) (color-values beacon-color))
               ((< (color-distance "black" bg)


### PR DESCRIPTION
Default backgroud color is unspecified-fg or unspecified-bg if emacs runs in
no-window mode(emacs -nw). '(color-values "unspecified-[fb]g")' returns nil
and beacon--color-range raises error.

Applying this patch uses fallback color instead of default background color.

## Original code

I got error `Invalid color`.

![output](https://cloud.githubusercontent.com/assets/554281/10777622/a42730d0-7d60-11e5-9f52-9333cd35c9c8.gif)

## With this change

![after](https://cloud.githubusercontent.com/assets/554281/10777650/ed25ffe6-7d60-11e5-8f6f-daa59cd5f8ef.gif)

