### PR TITLE
Don't crash when Emacs runs as a daemon

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -280,9 +280,10 @@ Only returns `beacon-size' elements."
                        (color-distance "white" bg)))
                (make-list 3 (* beacon-color 65535)))
               (t (make-list 3 (* (- 1 beacon-color) 65535))))))
-    (apply #'seq-mapn (lambda (r g b) (format "#%04x%04x%04x" r g b))
-           (mapcar (lambda (n) (butlast (beacon--int-range (elt fg n) (elt bg n))))
-                   [0 1 2]))))
+    (when bg
+      (apply #'seq-mapn (lambda (r g b) (format "#%04x%04x%04x" r g b))
+             (mapcar (lambda (n) (butlast (beacon--int-range (elt fg n) (elt bg n))))
+                     [0 1 2])))))
 
 
 ;;; Blinking


### PR DESCRIPTION
When `beacon--color-range` is executed while Emacs daemon is starting,
`color-values` returns `nil` and `beacon--color-range` was crashing.
This patch fixes the problem by making the function return an empty
color range instead.