### PR TITLE
Fix beacon at end of a long line

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -232,13 +232,20 @@ If COLORS is nil, OVERLAY is deleted!"
                              "")
                   'cursor 1000))))
 
+(defun beacon--visual-current-column ()
+  "Get the visual column we are at, takes long lines and visual line mode into account."
+  (save-excursion
+    (let ((current (point)))
+      (beginning-of-visual-line)
+      (- current (point)))))
+
 (defun beacon--after-string-overlay (colors)
   "Put an overlay at point with an after-string property.
 The property's value is a string of spaces with background
 COLORS applied to each one."
   ;; The after-string must not be longer than the remaining columns
   ;; from point to right window-end else it will be wrapped around.
-  (let ((colors (seq-take colors (- (window-width) (current-column) 1))))
+  (let ((colors (seq-take colors (- (window-width) (beacon--visual-current-column) 1))))
     (beacon--ov-put-after-string (beacon--make-overlay 0) colors)))
 
 (defun beacon--ov-at-point ()


### PR DESCRIPTION
Beacon refuses to blink at the end of a long line (a line that is longer than `(window-width)`). While we do not usually have long lines in programming, long lines are common for general text writing (and for me, LaTeX). This pull request fixes this by giving the distance between the current point and the start of the current visual line. A simpler fix would be replacing `(current-column)` with `(mod (current-column) (window-width)`, which does not work for visual line mode.