### PR TITLE
Fix warning of obsolete positional arguments in 'define-minor-mode'

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -464,7 +464,8 @@ unreliable, so just blink immediately."
 
 ;;;###autoload
 (define-minor-mode beacon-mode
-  nil nil beacon-lighter nil
+  nil
+  :lighter beacon-lighter
   :global t
   (if beacon-mode
       (progn


### PR DESCRIPTION
https://git.savannah.gnu.org/cgit/emacs.git/commit/?h=emacs-28&id=6bec60ad3151825c2ee5f775848ea3d4c70c72a5