### PR TITLE
Use correct emacs version dependency

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/Malabarba/beacon
 ;; Keywords: convenience
 ;; Version: 1.3.4
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "27.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fixes #87, assuming you don't care about supporting older versions.