### PR TITLE
beacon.el (define-minor-mode): Depreciated positional args -> kwargs

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -464,7 +464,8 @@ unreliable, so just blink immediately."
 
 ;;;###autoload
 (define-minor-mode beacon-mode
-  nil nil beacon-lighter nil
+  nil
+  :lighter beacon-lighter
   :global t
   (if beacon-mode
       (progn


### PR DESCRIPTION
GNU Emacs 29.0.50:
"Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'"