### PR TITLE
fixed issues with beacon--post-command() mproved functionality on m1 macs

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -1,5 +1,10 @@
 #+TITLE: Beacon --- Never lose your cursor again
 
+I forked and updated this as multiple functionalities of the package were not
+working out of the box. I fixed issues on for running on M1 macs where the
+cursor wouldn't blink for vertical movements or window changes. This repository
+is not in ELPA or MELPA and would require installing this locally.
+
 This is a global minor-mode.  Turn it on everywhere with:
 #+BEGIN_SRC emacs-lisp
 (beacon-mode 1)
@@ -35,7 +40,8 @@ That’s it.
   distance. For this, configure ~beacon-push-mark~.
 
 ** Contributors
-
+ 
 - [[https://github.com/tsdh][Tassilo Horn]]
+- [[https://www.github.com/antonhibl][Anton Hibl]]
 
-If you’d like to help too, just open a PR.
+If you’d like to help too, just open a PR or a fork.

--- a/beacon.el
+++ b/beacon.el
@@ -438,37 +438,42 @@ The same is true for DELTA-X and horizonta movement."
 ;;  (setq beacon--window-scrolled nil))
 
 (defun beacon--post-command ()
-"Blink if point moved very far."
-(cond
-;; Sanity check.
-((not (markerp beacon--previous-place)))
-;; Blink for switching buffers.
-((and beacon-blink-when-buffer-changes
-(not (eq (marker-buffer beacon--previous-place)
-(current-buffer))))
-(beacon-blink-automated))
-;; Blink for switching windows.
-((and beacon-blink-when-window-changes
-(not (eq beacon--previous-window (selected-window))))
-(beacon-blink-automated))
-;; Blink for scrolling.
-((and beacon--window-scrolled
-(equal beacon--window-scrolled (selected-window)))
-(beacon-blink-automated))
-;; Blink for movement
-((or (beacon--movement-> beacon-blink-when-point-moves-vertically
-beacon-blink-when-point-moves-horizontally)
-(and beacon-blink-when-point-moves-vertically
-(beacon--vertical-movement->)))
-(beacon-blink-automated)))
-(beacon--maybe-push-mark)
-(setq beacon--window-scrolled nil))
+  "Check if point has moved far and call `beacon-blink-automated'.
+
+The distance is determined by values of `beacon-blink-when-buffer-changes',
+`beacon-blink-when-window-changes', `beacon-blink-when-point-moves-vertically'"
+  (cond
+   ;; Sanity check.
+   ((not (markerp beacon--previous-place)))
+   ;; Blink for switching buffers.
+   ((and beacon-blink-when-buffer-changes
+         (not (eq (marker-buffer beacon--previous-place)
+                  (current-buffer))))
+    (beacon-blink-automated))
+   ;; Blink for switching windows.
+   ((and beacon-blink-when-window-changes
+         (not (eq beacon--previous-window (selected-window))))
+    (beacon-blink-automated))
+   ;; Blink for scrolling.
+   ((and beacon--window-scrolled
+         (equal beacon--window-scrolled (selected-window)))
+    (beacon-blink-automated))
+   ;; Blink for movement
+   ((or (beacon--movement-> beacon-blink-when-point-moves-vertically
+                            beacon-blink-when-point-moves-horizontally)
+        (and beacon-blink-when-point-moves-vertically
+             (beacon--vertical-movement->)))
+    (beacon-blink-automated)))
+  (beacon--maybe-push-mark)
+  (setq beacon--window-scrolled nil))
 
 (defun beacon--vertical-movement-> ()
-"Check if point has moved vertically."
-(let ((previous-line (line-number-at-pos beacon--previous-place))
-(current-line (line-number-at-pos (point))))
-(not (equal previous-line current-line))))
+  "Check if point has moved vertically.
+
+Compares line numbers of previous and current position."
+  (let ((previous-line (line-number-at-pos beacon--previous-place))
+        (current-line (line-number-at-pos (point))))
+    (not (equal previous-line current-line))))
 
 (defun beacon--window-scroll-function (window start-pos)
   "Blink the beacon or record that WINDOW has been scrolled.

--- a/beacon.el
+++ b/beacon.el
@@ -166,9 +166,8 @@ one of the major-modes on this list, the beacon will not
 blink."
   :type '(repeat symbol))
 
-(defcustom beacon-dont-blink-commands '()
-                                        ;;next-line previous-line
-                                            ;;forward-line)
+(defcustom beacon-dont-blink-commands '(next-line previous-line
+                                            forward-line)
   "A list of commands that should not make the beacon blink.
 Use this for commands that scroll the window in very
 predictable ways, when the blink would be more distracting

--- a/beacon.el
+++ b/beacon.el
@@ -412,31 +412,6 @@ The same is true for DELTA-X and horizonta movement."
                  (not (equal head beacon--previous-place)))
         (push-mark beacon--previous-place 'silent)))))
 
-;;(defun beacon--post-command ()
-;;  "Blink if point moved very far."
-;;  (cond
-;;   ;; Sanity check.
-;;   ((not (markerp beacon--previous-place)))
-;;   ;; Blink for switching buffers.
-;;   ((and beacon-blink-when-buffer-changes
-;;         (not (eq (marker-buffer beacon--previous-place)
-;;                  (current-buffer))))
-;;    (beacon-blink-automated))
-;;   ;; Blink for switching windows.
-;;   ((and beacon-blink-when-window-changes
-;;         (not (eq beacon--previous-window (selected-window))))
-;;    (beacon-blink-automated))
-;;   ;; Blink for scrolling.
-;;   ((and beacon--window-scrolled
-;;         (equal beacon--window-scrolled (selected-window)))
-;;    (beacon-blink-automated))
-;;   ;; Blink for movement
-;;   ((beacon--movement-> beacon-blink-when-point-moves-vertically
-;;                  beacon-blink-when-point-moves-horizontally)
-;;    (beacon-blink-automated)))
-;;  (beacon--maybe-push-mark)
-;;  (setq beacon--window-scrolled nil))
-
 (defun beacon--post-command ()
   "Check if point has moved far and call `beacon-blink-automated'.
 

--- a/beacon.el
+++ b/beacon.el
@@ -166,8 +166,9 @@ one of the major-modes on this list, the beacon will not
 blink."
   :type '(repeat symbol))
 
-(defcustom beacon-dont-blink-commands '(next-line previous-line
-                                            forward-line)
+(defcustom beacon-dont-blink-commands '()
+                                        ;;next-line previous-line
+                                            ;;forward-line)
   "A list of commands that should not make the beacon blink.
 Use this for commands that scroll the window in very
 predictable ways, when the blink would be more distracting
@@ -412,30 +413,63 @@ The same is true for DELTA-X and horizonta movement."
                  (not (equal head beacon--previous-place)))
         (push-mark beacon--previous-place 'silent)))))
 
+;;(defun beacon--post-command ()
+;;  "Blink if point moved very far."
+;;  (cond
+;;   ;; Sanity check.
+;;   ((not (markerp beacon--previous-place)))
+;;   ;; Blink for switching buffers.
+;;   ((and beacon-blink-when-buffer-changes
+;;         (not (eq (marker-buffer beacon--previous-place)
+;;                  (current-buffer))))
+;;    (beacon-blink-automated))
+;;   ;; Blink for switching windows.
+;;   ((and beacon-blink-when-window-changes
+;;         (not (eq beacon--previous-window (selected-window))))
+;;    (beacon-blink-automated))
+;;   ;; Blink for scrolling.
+;;   ((and beacon--window-scrolled
+;;         (equal beacon--window-scrolled (selected-window)))
+;;    (beacon-blink-automated))
+;;   ;; Blink for movement
+;;   ((beacon--movement-> beacon-blink-when-point-moves-vertically
+;;                  beacon-blink-when-point-moves-horizontally)
+;;    (beacon-blink-automated)))
+;;  (beacon--maybe-push-mark)
+;;  (setq beacon--window-scrolled nil))
+
 (defun beacon--post-command ()
-  "Blink if point moved very far."
-  (cond
-   ;; Sanity check.
-   ((not (markerp beacon--previous-place)))
-   ;; Blink for switching buffers.
-   ((and beacon-blink-when-buffer-changes
-         (not (eq (marker-buffer beacon--previous-place)
-                  (current-buffer))))
-    (beacon-blink-automated))
-   ;; Blink for switching windows.
-   ((and beacon-blink-when-window-changes
-         (not (eq beacon--previous-window (selected-window))))
-    (beacon-blink-automated))
-   ;; Blink for scrolling.
-   ((and beacon--window-scrolled
-         (equal beacon--window-scrolled (selected-window)))
-    (beacon-blink-automated))
-   ;; Blink for movement
-   ((beacon--movement-> beacon-blink-when-point-moves-vertically
-                  beacon-blink-when-point-moves-horizontally)
-    (beacon-blink-automated)))
-  (beacon--maybe-push-mark)
-  (setq beacon--window-scrolled nil))
+"Blink if point moved very far."
+(cond
+;; Sanity check.
+((not (markerp beacon--previous-place)))
+;; Blink for switching buffers.
+((and beacon-blink-when-buffer-changes
+(not (eq (marker-buffer beacon--previous-place)
+(current-buffer))))
+(beacon-blink-automated))
+;; Blink for switching windows.
+((and beacon-blink-when-window-changes
+(not (eq beacon--previous-window (selected-window))))
+(beacon-blink-automated))
+;; Blink for scrolling.
+((and beacon--window-scrolled
+(equal beacon--window-scrolled (selected-window)))
+(beacon-blink-automated))
+;; Blink for movement
+((or (beacon--movement-> beacon-blink-when-point-moves-vertically
+beacon-blink-when-point-moves-horizontally)
+(and beacon-blink-when-point-moves-vertically
+(beacon--vertical-movement->)))
+(beacon-blink-automated)))
+(beacon--maybe-push-mark)
+(setq beacon--window-scrolled nil))
+
+(defun beacon--vertical-movement-> ()
+"Check if point has moved vertically."
+(let ((previous-line (line-number-at-pos beacon--previous-place))
+(current-line (line-number-at-pos (point))))
+(not (equal previous-line current-line))))
 
 (defun beacon--window-scroll-function (window start-pos)
   "Blink the beacon or record that WINDOW has been scrolled.
@@ -459,12 +493,11 @@ unreliable, so just blink immediately."
   (when beacon-blink-when-focused
     (beacon-blink-automated)))
 
-
 ;;; Minor-mode
 (defcustom beacon-lighter
   (cond
-   ;; ((char-displayable-p ?💡) " 💡")
-   ;; ((char-displayable-p ?Λ) " Λ")
+    ((char-displayable-p ?💡) " 💡")
+    ((char-displayable-p ?Λ) " Λ")
    (t " (*)"))
   "Lighter string used on the mode-line."
   :type 'string)

--- a/beacon.el
+++ b/beacon.el
@@ -495,8 +495,8 @@ unreliable, so just blink immediately."
 ;;; Minor-mode
 (defcustom beacon-lighter
   (cond
-    ((char-displayable-p ?💡) " 💡")
-    ((char-displayable-p ?Λ) " Λ")
+    ;;((char-displayable-p ?💡) " 💡")
+    ;;((char-displayable-p ?Λ) " Λ")
    (t " (*)"))
   "Lighter string used on the mode-line."
   :type 'string)


### PR DESCRIPTION
This code adds a new function beacon--vertical-movement-> which checks if the cursor has moved vertically by comparing the line numbers of the previous position and the current position. If the line numbers are different, it means that the cursor has moved vertically.

The beacon--post-command function has been updated to include this new check for vertical movement by adding an or statement for beacon-blink-when-point-moves-vertically and beacon--vertical-movement->. 

If you care about supporting M1 chips for this package going forward this is relevant as the package is pretty much not functional on these chips without these changes.