### PR TITLE
Some solutions to misconfiguration

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -378,7 +378,8 @@ variables: `beacon-mode', `beacon-dont-blink-commands',
   "Return non-nil if latest vertical movement is > DELTA-Y.
 If DELTA-Y is nil, return nil.
 The same is true for DELTA-X and horizonta movement."
-  (and delta-y
+
+  (and (numberp delta-y)
        (markerp beacon--previous-place)
        (equal (marker-buffer beacon--previous-place)
               (current-buffer))
@@ -387,7 +388,7 @@ The same is true for DELTA-X and horizonta movement."
        (> (abs (- (point) beacon--previous-place))
           delta-y)
        ;; Col movement.
-       (or (and delta-x
+       (or (and (numberp delta-x)
                 (> (abs (- (current-column)
                            (save-excursion
                              (goto-char beacon--previous-place)

--- a/beacon.el
+++ b/beacon.el
@@ -481,6 +481,18 @@ unreliable, so just blink immediately."
   :global t
   (if beacon-mode
       (progn
+        ;; Fail when misconfigured.
+        (when (and beacon-blink-when-point-moves-horizontally
+                   (not (numberp beacon-blink-when-point-moves-horizontally)))
+          (user-error
+           "When non-nil, beacon-blink-when-point-moves-horizontally is not an integer: %s"
+           beacon-blink-when-point-moves-horizontally))
+        (when (and beacon-blink-when-point-moves-vertically
+                   (not (numberp beacon-blink-when-point-moves-vertically)))
+          (user-error
+           "When non-nil, beacon-blink-when-point-moves-vertically is not an integer: %s"
+           beacon-blink-when-point-moves-vertically))
+
         (add-hook 'window-scroll-functions #'beacon--window-scroll-function)
         (add-function :after after-focus-change-function
                       #'beacon--blink-on-focus)

--- a/beacon.el
+++ b/beacon.el
@@ -379,6 +379,11 @@ variables: `beacon-mode', `beacon-dont-blink-commands',
 If DELTA-Y is nil, return nil.
 The same is true for DELTA-X and horizonta movement."
 
+  (when (and delta-y (not (numberp delta-y)))
+    (warn "beacon-blink-when-point-moves-vertically is not an integer."))
+  (when (and delta-x (not (numberp delta-x)))
+    (warn "beacon-blink-when-point-moves-horizontally is not an integer."))
+
   (and (numberp delta-y)
        (markerp beacon--previous-place)
        (equal (marker-buffer beacon--previous-place)


### PR DESCRIPTION
As mentioned in #78 it's pretty easy to assume these two values are boolean settings and to cause bugs intermittently when the fall-through condition is evaluated in the post command

I made three separate solutions to look at, with varying degrees of feedback and error avoidance (but hiding the lack of user intended behavior)

Happy to remove whichever solutions are unwanted.